### PR TITLE
Fix Trainer legacy migration and install docs

### DIFF
--- a/.github/workflows/trainer-release.yml
+++ b/.github/workflows/trainer-release.yml
@@ -35,11 +35,11 @@ jobs:
             echo "Tag must use trainer-vMAJOR.MINOR.PATCH format." >&2
             exit 1
           fi
+          git fetch --force --tags origin
           if [[ "$(git cat-file -t "refs/tags/$TAG_NAME")" != "tag" ]]; then
             echo "$TAG_NAME must be an annotated tag." >&2
             exit 1
           fi
-          git fetch --force --tags origin
           git fetch origin \
             '+refs/heads/master:refs/remotes/origin/master' \
             '+refs/heads/trainer:refs/remotes/origin/trainer'

--- a/scripts/stage-trainer-runtime.py
+++ b/scripts/stage-trainer-runtime.py
@@ -142,6 +142,7 @@ def stage_flatpak(bundle: Path, output: Path, epoch: int) -> None:
     try:
         copy_host_runtime(temporary)
         copy_file(TRAINER_SOURCE / "install-flatpak.sh", temporary / "trainer/install-flatpak.sh")
+        copy_file(TRAINER_SOURCE / "install.sh", temporary / "trainer/install.sh")
         copy_file(
             bundle,
             temporary / "trainer/io.github.keyboardspecialist.bc250trainer.flatpak",

--- a/tests/test_trainer_release.py
+++ b/tests/test_trainer_release.py
@@ -128,6 +128,47 @@ class TrainerReleaseTests(unittest.TestCase):
         )
         self.assertIn("{install|status|uninstall|uninstall-legacy|help}", result.stdout)
 
+    def test_legacy_uninstall_accepts_pre_media_owned_install(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            home = Path(temporary) / "home"
+            app = home / ".local/libexec/bc250-cracktro"
+            desktop = home / ".local/share/applications/io.github.keyboardspecialist.bc250cracktro.desktop"
+            icon = home / ".local/share/icons/hicolor/scalable/apps/io.github.keyboardspecialist.bc250cracktro.svg"
+            app.mkdir(parents=True)
+            desktop.parent.mkdir(parents=True)
+            icon.parent.mkdir(parents=True)
+            (app / ".bc250-cracktro-owner").write_text(
+                "schema=1;owner=io.github.keyboardspecialist.bc250cracktro\n",
+                encoding="ascii",
+            )
+            (app / "bc250-cracktro").write_bytes(b"legacy executable")
+            desktop.write_text(
+                "[Desktop Entry]\n"
+                "X-BC250-Installer-Owner=io.github.keyboardspecialist.bc250cracktro\n"
+                f"Exec={app}/bc250-cracktro\n",
+                encoding="utf-8",
+            )
+            icon.write_text("legacy icon\n", encoding="ascii")
+            bindir = Path(temporary) / "bin"
+            bindir.mkdir()
+            sudo = bindir / "sudo"
+            sudo.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
+            sudo.chmod(0o755)
+            environment = os.environ.copy()
+            environment["HOME"] = str(home)
+            environment["PATH"] = f"{bindir}:{environment['PATH']}"
+
+            subprocess.run(
+                ["bash", str(INSTALLER), "uninstall-legacy"],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertFalse(app.exists())
+            self.assertFalse(desktop.exists())
+            self.assertFalse(icon.exists())
+
     def test_flatpak_installation_kit_contains_gui_and_host_service(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -155,6 +196,7 @@ class TrainerReleaseTests(unittest.TestCase):
                 names = set(archive.namelist())
                 for expected in (
                     "trainer/install-flatpak.sh",
+                    "trainer/install.sh",
                     "trainer/io.github.keyboardspecialist.bc250trainer.flatpak",
                     "desktop-control/shared-service-install.sh",
                     "desktop-control/service/bc250-control-service",
@@ -171,6 +213,7 @@ class TrainerReleaseTests(unittest.TestCase):
         self.assertIn("CLIENT=trainer-flatpak", installer)
         self.assertIn("flatpak install --user --noninteractive --or-update", installer)
         self.assertIn('sudo bash "$SOURCE_DIR/install-flatpak.sh" _install-root', installer)
+        self.assertIn('bash "$LEGACY_INSTALLER" uninstall-legacy', installer)
         result = subprocess.run(
             ["bash", str(FLATPAK_INSTALLER), "help"],
             check=True,

--- a/trainer/README.md
+++ b/trainer/README.md
@@ -7,6 +7,39 @@ The application does not invoke scripts, `sudo`, `busctl`, or any subprocess. Ha
 The Flatpak packages only this unprivileged frontend. Release installation kits
 pair it with a host-side installer for the required BC-250 control service.
 
+## Install
+
+Download one of the ZIP files from
+[BC250 Trainer Releases](https://github.com/keyboardspecialist/bc250-steamos/releases?q=trainer-v&expanded=true).
+Run these commands as your normal desktop user, not with `sudo`; the installer
+requests administrator access only for the host service.
+
+### Flatpak
+
+```sh
+unzip bc250-trainer-vX.Y.Z-flatpak-installer.zip
+cd bc250-trainer-flatpak-installer
+bash trainer/install-flatpak.sh install
+```
+
+Manage the installation from the same extracted directory:
+
+```sh
+bash trainer/install-flatpak.sh status
+bash trainer/install-flatpak.sh uninstall
+```
+
+### Native Linux
+
+```sh
+unzip bc250-trainer-vX.Y.Z.zip
+cd bc250-trainer
+bash trainer/install.sh install
+```
+
+The native package uses `bash trainer/install.sh status` and
+`bash trainer/install.sh uninstall` for management.
+
 ## Features
 
 - Status dashboard with one-second telemetry while the page is active
@@ -42,8 +75,8 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
-On macOS, install the required formulae and run the same build and verification
-path used by CI:
+On macOS, install the required formulae and run the internal manual build and
+verification harness:
 
 ```sh
 brew install cmake ninja qt bash coreutils

--- a/trainer/install-flatpak.sh
+++ b/trainer/install-flatpak.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SOURCE_DIR/.." && pwd)"
 SHARED_INSTALLER="$REPO_DIR/desktop-control/shared-service-install.sh"
+LEGACY_INSTALLER="$SOURCE_DIR/install.sh"
 APP_ID=io.github.keyboardspecialist.bc250trainer
 CLIENT=trainer-flatpak
 BUNDLE="${BC250_TRAINER_FLATPAK_BUNDLE:-$SOURCE_DIR/$APP_ID.flatpak}"
@@ -19,6 +20,16 @@ require_normal_user() { [[ $EUID -ne 0 ]] || die "Run as the logged-in desktop u
     || die "Shared service installer is missing or unsafe: $SHARED_INSTALLER"
 # shellcheck source=../desktop-control/shared-service-install.sh
 source "$SHARED_INSTALLER"
+
+legacy_present() {
+    [[ -e "$HOME/.local/libexec/bc250-cracktro" \
+        || -L "$HOME/.local/libexec/bc250-cracktro" \
+        || -e "$HOME/.local/share/applications/io.github.keyboardspecialist.bc250cracktro.desktop" \
+        || -L "$HOME/.local/share/applications/io.github.keyboardspecialist.bc250cracktro.desktop" \
+        || -e "$HOME/.local/share/icons/hicolor/scalable/apps/io.github.keyboardspecialist.bc250cracktro.svg" \
+        || -L "$HOME/.local/share/icons/hicolor/scalable/apps/io.github.keyboardspecialist.bc250cracktro.svg" \
+        || -e "$SHARED_CLIENT_DIR/cracktro.$(id -u)" ]]
+}
 
 legacy_client() {
     if [[ -d "$HOME/.local/share/plasma/plasmoids/io.github.keyboardspecialist.bc250control" ]] \
@@ -56,6 +67,13 @@ install_all() {
         [[ $had_service -eq 1 ]] \
             || sudo bash "$SOURCE_DIR/install-flatpak.sh" _uninstall-root "$CLIENT" "$uid" || true
         die "Could not install the BC250 Trainer Flatpak."
+    fi
+    if legacy_present; then
+        [[ -f "$LEGACY_INSTALLER" && ! -L "$LEGACY_INSTALLER" ]] \
+            || die "BC250 Trainer installed, but the legacy cleanup helper is missing or unsafe."
+        log "Removing the ownership-verified legacy Cracktro installation"
+        bash "$LEGACY_INSTALLER" uninstall-legacy \
+            || die "BC250 Trainer installed, but the legacy Cracktro installation could not be removed."
     fi
     log "BC250 Trainer installed as $APP_ID"
 }

--- a/trainer/install.sh
+++ b/trainer/install.sh
@@ -86,13 +86,16 @@ legacy_install_owned() {
     [[ -d "$LEGACY_APP_DIR" && ! -L "$LEGACY_APP_DIR" \
         && -f "$LEGACY_OWNER_FILE" && ! -L "$LEGACY_OWNER_FILE" \
         && -f "$LEGACY_APP_BIN" && ! -L "$LEGACY_APP_BIN" \
-        && -d "$LEGACY_TRACKS" && ! -L "$LEGACY_TRACKS" \
         && -f "$LEGACY_DESKTOP_FILE" && ! -L "$LEGACY_DESKTOP_FILE" \
         && -f "$LEGACY_ICON_FILE" && ! -L "$LEGACY_ICON_FILE" ]] || return 1
     for path in "$LEGACY_APP_DIR" "$LEGACY_OWNER_FILE" "$LEGACY_APP_BIN" \
-        "$LEGACY_TRACKS" "$LEGACY_DESKTOP_FILE" "$LEGACY_ICON_FILE"; do
+        "$LEGACY_DESKTOP_FILE" "$LEGACY_ICON_FILE"; do
         [[ "$(stat -Lc '%u' "$path")" == "$uid" ]] || return 1
     done
+    if [[ -e "$LEGACY_TRACKS" || -L "$LEGACY_TRACKS" ]]; then
+        [[ -d "$LEGACY_TRACKS" && ! -L "$LEGACY_TRACKS" \
+            && "$(stat -Lc '%u' "$LEGACY_TRACKS")" == "$uid" ]] || return 1
+    fi
     [[ "$(cat "$LEGACY_OWNER_FILE")" == "$LEGACY_OWNER_VALUE" ]] \
         && grep -Fxq "X-BC250-Installer-Owner=$LEGACY_APP_ID" "$LEGACY_DESKTOP_FILE" \
         && grep -Fxq "Exec=$LEGACY_APP_BIN" "$LEGACY_DESKTOP_FILE"


### PR DESCRIPTION
## Summary
- remove ownership-verified legacy Cracktro launchers after a successful Flatpak Trainer install
- accept older Cracktro installs that predate the bundled tracks directory
- include the legacy cleanup helper in Flatpak installation kits
- add simple native and Flatpak release install, status, and uninstall instructions
- fetch annotated Trainer tags before release validation

## Verification
- 20 focused Trainer release and maintenance tests
- shell syntax, Python compilation, and diff checks