### PR TITLE
Release BC250 Trainer from master

### DIFF
--- a/.github/workflows/trainer-checks.yml
+++ b/.github/workflows/trainer-checks.yml
@@ -18,7 +18,7 @@ on:
       - ".github/workflows/release-artifacts.yml"
   push:
     branches:
-      - trainer
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/trainer-release.yml
+++ b/.github/workflows/trainer-release.yml
@@ -41,10 +41,9 @@ jobs:
             exit 1
           fi
           git fetch origin \
-            '+refs/heads/master:refs/remotes/origin/master' \
-            '+refs/heads/trainer:refs/remotes/origin/trainer'
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/trainer; then
-            echo "BC250 Trainer release tags must point to commits on the trainer branch." >&2
+            '+refs/heads/master:refs/remotes/origin/master'
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
+            echo "BC250 Trainer release tags must point to commits on master." >&2
             exit 1
           fi
           if grep -q '^Do not publish either asset in a release' trainer/ASSETS.md; then

--- a/tests/test_trainer_release.py
+++ b/tests/test_trainer_release.py
@@ -420,13 +420,13 @@ class TrainerReleaseTests(unittest.TestCase):
         ):
             self.assertIn(expected, workflow)
 
-    def test_trainer_release_has_isolated_branch_and_tag_namespace(self):
+    def test_trainer_release_has_isolated_tag_namespace(self):
         workflow = (ROOT / ".github/workflows/trainer-release.yml").read_text(
             encoding="utf-8"
         )
         for expected in (
             '"trainer-v*"',
-            "BC250 Trainer release tags must point to commits on the trainer branch",
+            "BC250 Trainer release tags must point to commits on master",
             "TRAINER_PROJECT_VERSION",
             "scripts/stage-trainer-runtime.py",
             "BC250 Trainer asset redistribution is not yet cleared",
@@ -439,6 +439,7 @@ class TrainerReleaseTests(unittest.TestCase):
             self.assertIn(expected, workflow)
         self.assertNotIn('tags:\n      - "v*"', workflow)
         self.assertNotIn("workflow_dispatch", workflow)
+        self.assertNotIn("origin/trainer", workflow)
 
         cmake = (ROOT / "trainer/CMakeLists.txt").read_text(encoding="utf-8")
         self.assertIn("TRAINER_PROJECT_VERSION", cmake)

--- a/trainer/README.md
+++ b/trainer/README.md
@@ -159,16 +159,16 @@ BC250 Trainer releases use the independent `trainer-vMAJOR.MINOR.PATCH` tag
 namespace and are published as GitHub prereleases. Main toolkit releases retain
 the `vMAJOR.MINOR.PATCH` namespace and existing release workflow.
 
-Cut a release from the `trainer` branch with an annotated tag:
+Cut a release from `master` with an annotated Trainer tag:
 
 ```sh
-git switch trainer
+git switch master
 git pull --ff-only
 git tag -a trainer-v1.0.0 -m "BC250 Trainer v1.0.0"
-git push origin trainer trainer-v1.0.0
+git push origin trainer-v1.0.0
 ```
 
-The **Build BC250 Trainer prerelease** workflow validates branch ancestry, builds
+The **Build BC250 Trainer prerelease** workflow validates master ancestry, builds
 and tests the native application and shared service, stages the standalone ZIP
 and complete Flatpak installation kit, and publishes checksums with the prerelease. Main `v*`
 toolkit releases publish the same Flatpak artifact.


### PR DESCRIPTION
## Summary
- validate future trainer-v* tags against master instead of a long-lived trainer branch
- run relevant Trainer Linux checks on master
- document cutting independent Trainer prereleases from master
- preserve the independent trainer-vMAJOR.MINOR.PATCH tag and artifact namespace

This allows the merged trainer branch to be deleted without breaking future Trainer releases.

## Verification
- Trainer release workflow tests pass
- diff and workflow checks pass